### PR TITLE
Thread、Comment の add、edit の created_at、updated_at を画面から外す

### DIFF
--- a/src/Template/Comments/add.ctp
+++ b/src/Template/Comments/add.ctp
@@ -15,8 +15,6 @@
             echo $this->Form->input('thread_id');
             echo $this->Form->input('actor_id');
             echo $this->Form->input('body');
-            echo $this->Form->input('created_at');
-            echo $this->Form->input('updated_at');
         ?>
     </fieldset>
     <?= $this->Form->button(__('Submit')) ?>

--- a/src/Template/Comments/edit.ctp
+++ b/src/Template/Comments/edit.ctp
@@ -22,8 +22,6 @@
             echo $this->Form->input('thread_id');
             echo $this->Form->input('actor_id');
             echo $this->Form->input('body');
-            echo $this->Form->input('created_at');
-            echo $this->Form->input('updated_at');
         ?>
     </fieldset>
     <?= $this->Form->button(__('Submit')) ?>

--- a/src/Template/Threads/add.ctp
+++ b/src/Template/Threads/add.ctp
@@ -11,8 +11,6 @@
         <?php
             echo $this->Form->input('title');
             echo $this->Form->input('body');
-            echo $this->Form->input('created_at');
-            echo $this->Form->input('updated_at');
         ?>
     </fieldset>
     <?= $this->Form->button(__('Submit')) ?>

--- a/src/Template/Threads/edit.ctp
+++ b/src/Template/Threads/edit.ctp
@@ -18,8 +18,6 @@
             echo $this->Form->input('actor_id');
             echo $this->Form->input('title');
             echo $this->Form->input('body');
-            echo $this->Form->input('created_at');
-            echo $this->Form->input('updated_at');
         ?>
     </fieldset>
     <?= $this->Form->button(__('Submit')) ?>


### PR DESCRIPTION
closed #70 
