### PR TITLE
#69 thread#edit、comment#edit の各画面から actor_idの指定をさせないように消す。

### DIFF
--- a/src/Template/Comments/edit.ctp
+++ b/src/Template/Comments/edit.ctp
@@ -18,9 +18,7 @@
     <fieldset>
         <legend><?= __('Edit Comment') ?></legend>
         <?php
-//            echo $this->Form->input('thread_id', ['options' => $threads]);
             echo $this->Form->input('thread_id');
-            echo $this->Form->input('actor_id');
             echo $this->Form->input('body');
         ?>
     </fieldset>

--- a/src/Template/Threads/edit.ctp
+++ b/src/Template/Threads/edit.ctp
@@ -15,7 +15,6 @@
     <fieldset>
         <legend><?= __('Edit Thread') ?></legend>
         <?php
-            echo $this->Form->input('actor_id');
             echo $this->Form->input('title');
             echo $this->Form->input('body');
         ?>


### PR DESCRIPTION
closed #69 
@ms2sato comment#edit後、thread#viewではなく、comment#indexに飛んでしまっています。
